### PR TITLE
Update policy 202306

### DIFF
--- a/docs/en/access_reuse.md
+++ b/docs/en/access_reuse.md
@@ -1,7 +1,7 @@
 
 ## 1.0 Scope & Purpose
 
-This policy covers the access and reuse of Content submitted to the Federated Research Data Repository (FRDR) website (the Site), <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a>, and the services available on or at the Site (taken together, the Service), including licensing, citation and attribution, and metrics and privacy. The access and reuse of Content from the metadata records of third-party repositories that are discoverable by searching the Site are governed by the license terms for the Content at the source repository. See the [Metadata Harvesting Policy](/policies/en/metadata_harvesting/) for complete information about the Service’s metadata harvesting protocols and activities associated with the search and discovery of third-party data repositories.
+This policy covers the access and reuse of Content submitted to the Federated Research Data Repository (FRDR) website (the Site), <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a>, and the services available on or at the Site (taken together, the Service), including licensing, citation and attribution, and metrics and privacy. The access and reuse of Content from the metadata records of third-party repositories that are discoverable by searching the Site are governed by the license terms for the Content at the source repository.
 
 This policy should be consulted in accordance with the [Terms of Use](/policies/en/terms_of_use/), [Privacy Policy](/policies/en/privacy/), the [Glossary of Terms](/policies/en/glossary/), and any other relevant policies.
 
@@ -39,5 +39,5 @@ Information about Users of and Submitters to the Service may be collected. See t
 
 This Policy enters into force on the date of its adoption. It will be reviewed by the FRDR Steering Committee every two years or at any time, as required.
 
-Last Revised: 2020-12-11
+Last Revised: 2023-06-12
 

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -10,7 +10,7 @@
 
 **Service**: The services available on or at the Site offered by the Service Host.
 
-**Service Host**: The legal entity responsible for offering the Service, being the New Digital Research Infrastructure Organization (NDRIO).
+**Service Host**: The legal entity responsible for offering the Service, being the Digital Research Alliance of Canada (Alliance).
 
 **Site**: Federated Research Data Repository (FRDR) website, https://www.frdr-dfdr.ca/
 
@@ -18,4 +18,4 @@
 
 **User**: An individual who makes use of the Service by either browsing the Site or downloading Content.
 
-*Last Revised: 2021-04-26*
+*Last Revised: 2023-06-12*

--- a/docs/en/privacy.md
+++ b/docs/en/privacy.md
@@ -1,4 +1,4 @@
-The following Privacy Policy applies to the Federated Research Data Repository (FRDR) website (the Site), <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a> and the services available on or at the Site. The Service is offered by the New Digital Research Infrastructure Organization (NDRIO) (hereafter: the Service Host).
+The following Privacy Policy applies to the Federated Research Data Repository (FRDR) website (the Site), <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a> and the services available on or at the Site. The Service is offered by the Digital Research Alliance of Canada (Alliance) (hereafter: the Service Host).
 
 ## Privacy Statement
 
@@ -22,7 +22,7 @@ If you do not agree with some or all of this Privacy Policy, please do not use t
 
 **Service**: The services available on or at the Site offered by the Service Host.
 
-**Service Host**: The legal entity responsible for offering the Service, being the New Digital Research Infrastructure Organization (NDRIO). Site: Federated Research Data Repository (FRDR) website, <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a>
+**Service Host**: The legal entity responsible for offering the Service, being the Digital Research Alliance of Canada (Alliance). Site: Federated Research Data Repository (FRDR) website, <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a>
 
 **Submitter**: An individual who publishes Content to the Service. It is anticipated that, in the majority of cases, the Submitter will be an author of the Content or associated datasets or a researcher collaborating with the author(s).
 
@@ -160,4 +160,4 @@ Should you have any questions or concerns about the collection, use, or disclosu
 
 The Service Host reserves the right to suspend use by any party (Submitter or User) if that party engages in, or is suspected of engaging in, activities that violate applicable information access and privacy laws.
 
-Last Revised: 2021-04-26
+Last Revised: 2023-06-14

--- a/docs/en/terms_of_use.md
+++ b/docs/en/terms_of_use.md
@@ -17,7 +17,7 @@ If you are not of the age of majority in your place of residence, do not agree w
 
 **Service**: The services available on or at the Site offered by the Service Host.
 
-**Service Host**: The legal entity responsible for offering the Service, being the New Digital Research Infrastructure Organization (NDRIO).
+**Service Host**: The legal entity responsible for offering the Service, being the Digital Research Alliance of Canada (Alliance).
 
 **Site**: Federated Research Data Repository (FRDR) website, [https://www.frdr-dfdr.ca/](https://www.frdr-dfdr.ca/)
 
@@ -136,31 +136,19 @@ All requests to temporarily or permanently withdraw from public access or remove
 
 While the Service Host will consider every request for editing, withdrawal or removal of the Content from the Service, the Service Host is not required to approve any such request. If the Service Host approves any such request, the Service Host will promptly notify the Submitter of such approval.
 
-## 7.0 Metadata
-
-The Service will harvest publicly available metadata distributed across multiple Canadian platforms and repositories.
-
-* Curators will ensure that harvested metadata meets internationally accepted best practices and standards.
-
-* The Service will not transfer or ingest any research data in this process with the exception of geospatial files available from open datasets which are downloaded to provide a geospatial preview of the file on FRDR. If the data is openly available, Users will be able to access the data from the source repository.
-
-* Metadata from the Service may be freely reused under the [Creative Commons Public Domain Dedication (CC0 1.0)](https://creativecommons.org/publicdomain/zero/1.0/).
-
-* Except as otherwise authorized under these Terms of Use, including section 2 above, bulk downloading of email addresses or other contact information taken from the Service is not permitted.
-
-## 8.0 Privacy
+## 7.0 Privacy
 
 The Service Host respects the privacy of Users and Submitters and will only collect, use, and disclose Personal Information in accordance with the FRDR Privacy Policy, which forms part of these Terms of Use. The Service Host encourages all Users and Submitters to review the Privacy Policy and use it to help make informed decisions.
 
-## 9.0 General Provisions
+## 8.0 General Provisions
 
-### 9.1 Suspension and Termination
+### 8.1 Suspension and Termination
 
 The Service Host reserves the right to immediately and without notice suspend any person’s (Submitter or User) access to and use of the Site or Service if that person engages in, or is suspected of engaging in, activities that violate applicable laws or otherwise do not comply with these Terms of Use.
 
 The Service Host may, in its sole discretion, provide a period of 15 days to cure or cease activities that violate these Terms of Use. If the Service Host provides a cure period and the offending activities are not cured or do not cease within the cure period, or if the Service Host determines that the breach of these Terms of Use cannot be cured, your account or access to the Site and Service will be terminated.
 
-### 9.2 Disclaimers
+### 8.2 Disclaimers
 
 The Site, Service and Content are made available to Submitters and Users on an "AS IS" basis and you acknowledge and agree that your use of the Site, Service and Content are at your sole risk.
 
@@ -174,7 +162,7 @@ The Service Host does not represent, warrant or covenant that:
 
 Except as set forth herein, and to the maximum extent permitted by law, the Service Host disclaims any and all representations, warranties and conditions with respect to the Site, Service and Content, whether express, implied, statutory or otherwise, or arising by course of dealing or usage of trade, including, without limitation, warranties of title, non-infringement, quality, performance, compatibility, merchantability, and/or fitness for a particular purpose. The Service Host assumes no responsibility for, and is not liable for, any damage to your equipment, data or other property as a result of your access to, use of or browsing on the Site or Services or your downloading of any Content or other materials, or inability to do any of the foregoing.
 
-### 9.3 Liability and Indemnity
+### 8.3 Liability and Indemnity
 
 To the extent not prohibited by law, the Service Host will not be liable for any damages whatsoever, including direct, indirect, incidental, punitive, special, consequential or exemplary damages arising from, relating to or connected with:
 
@@ -190,21 +178,21 @@ This is a comprehensive limitation of liability that applies to all losses and d
 
 You will indemnify, defend and hold the Service Host harmless from and against any claim, demand, action, loss, cost, expense, liability, or damage, including, without limitation, all reasonable legal fees and costs, investigation costs and settlement expenses, arising from (i) the use or misuse of the Site or Service; (ii) your access to the Site, use of the Services, use of the Content or violation of these Terms of Use; (iii) any injury, death or damage to property caused or contributed to by you; or (iv) the infringement by you, or any third party using your account, of any intellectual property or other right of any third party in any way relating to the Terms of Use, the Site, Service or Content.
 
-### 9.4 Dispute Resolution
+### 8.4 Dispute Resolution
 
 These Terms of Use, your use of the Site and Service and all disputes arising from it in connection with these Terms of Use shall be exclusively governed by and interpreted in accordance with the laws of Ontario and the federal laws of Canada applicable in Ontario without regard to conflict of laws principles. You agree that, despite being available from a variety of jurisdictions, the Site and Service will be deemed solely based in the Province of Ontario, Canada; and the Site and Service will be deemed to be passive in nature and not giving rise to personal jurisdiction over the Service Host in jurisdictions other than the Province of Ontario. The parties irrevocably submit to the exclusive jurisdiction of the courts of the Province of Ontario for any actions or proceedings arising out of or relating to the enforcement of these Terms of Use. However, you agree that nothing in these Terms of Use precludes the Service Host from applying for injunctive remedies or other urgent legal relief in any jurisdiction.
 
-### 9.5 Entire Agreement and Severability
+### 8.5 Entire Agreement and Severability
 
 The Terms of Use, together with the Privacy Policy and other documents incorporated by reference into these Terms of Use, constitute the entire agreement between you and the Service Host with respect to the subject matter of these Terms of Use, and supersede all prior or contemporaneous agreements, negotiations communications and proposals (whether oral, written or electronic) between you and the Service Host with respect to the subject matter of these Terms of Use. If any provision of the Terms of Use is found to be unenforceable or invalid, that provision will be limited or eliminated to the minimum extent necessary so that the Terms of Use will otherwise remain in full force and effect and enforceable.
 
-### 9.6 Changes to Terms of Use
+### 8.6 Changes to Terms of Use
 
 The Service Host reserves the right, at their sole discretion, to modify or replace these Terms of Use at any time, in which case the modified or updated Terms of Use will supersede prior versions. If the Service Host makes changes to these Terms of Use, the updated Terms of Use will be posted on the Site.
 
 It is your responsibility to check the Terms of Use periodically for changes. Your continued use of the Site and/or Service following the posting of any changes to the Terms of Use constitutes acceptance of those changes.
 
-### 9.7 Contacting Us
+### 8.7 Contacting Us
 
 If you have any questions or comments with respect to the Site or Service, if you are unsure whether your intended use is in line with these Terms of Use, or if you seek
 
@@ -212,8 +200,8 @@ permission for a use that does not fall within these Terms of Use, please contac
 
 If you have any questions or concerns about the collection, use, or disclosure of Personal Information as regards FRDR, please view the Privacy Policy or contact us at [privacy@frdr-dfdr.ca](mailto:privacy@frdr-dfdr.ca).
 
-### 9.8 Proprietary Rights
+### 8.8 Proprietary Rights
 
 You acknowledge and agree that the all rights, title and interest in and to the Sites, Service, any additional data added by the Service Host to the Content and any trademarks, search software, user guides, documentation and other intellectual property that is created by or on behalf the Service Host relating to the Site or Service, including the submission of Content, is owned solely by the Service Host and their licensees.
 
-Last Revised: 2021-11-23
+Last Revised: 2023-06-14

--- a/docs/fr/accès_réutilisation.md
+++ b/docs/fr/accès_réutilisation.md
@@ -1,7 +1,7 @@
 
 ## 1.0 Champ d’application et objectif
 
-La présente politique couvre l’accès et la réutilisation du contenu soumis au site web du Dépôt fédéré de données de recherche (DFDR) (le site), <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a>, et les services disponibles sur le site ou à partir de celui-ci (collectivement, le service), y compris l’octroi de licences, la citation et l’attribution, ainsi que les mesures et la protection de confidentialité. L’accès et la réutilisation du contenu provenant des fichiers de métadonnées de dépôts indépendants pouvant être découverts en effectuant une recherche sur le site sont régis par les conditions de licence du contenu du dépôt original. Consultez la Politique en matière de moissonnage de métadonnées pour des précisions sur les protocoles de moissonnage de métadonnées du service et les activités associées à la recherche et à la découverte de dépôts de données indépendants.
+La présente politique couvre l’accès et la réutilisation du contenu soumis au site web du Dépôt fédéré de données de recherche (DFDR) (le site), <a href="https://www.frdr-dfdr.ca/">https://www.frdr-dfdr.ca/</a>, et les services disponibles sur le site ou à partir de celui-ci (collectivement, le service), y compris l’octroi de licences, la citation et l’attribution, ainsi que les mesures et la protection de confidentialité. L’accès et la réutilisation du contenu provenant des fichiers de métadonnées de dépôts indépendants pouvant être découverts en effectuant une recherche sur le site sont régis par les conditions de licence du contenu du dépôt original.
 
 La présente politique devrait être consultée parallèlement aux [conditions d’utilisation](/policies/fr/conditions_d'utilisation/), [à la politique de confidentialité](/policies/fr/confidentialité/), au [glossaire terminologique](/policies/fr/glossaire/) et à toute autre politique pertinente.
 
@@ -39,5 +39,5 @@ Des informations sur les utilisateurs et les déposants du service peuvent être
 
 La présente politique entre en vigueur à la date de son adoption. Elle sera révisée par le comité de pilotage du DFDR tous les deux ans ou de manière ponctuelle au besoin.
 
-Dernière révision : 2020-12-11
+Dernière révision : 2023-06-12
 

--- a/docs/fr/conditions_d'utilisation.md
+++ b/docs/fr/conditions_d'utilisation.md
@@ -20,7 +20,7 @@ On entend par:
 
 **Service**, les services disponibles dans le site proposés par l’hébergeur du service.
 
-**Hébergeur du service**, l’entité juridique chargée d’offrir le service, soit la Nouvelle organisation d’infrastructure de recherche numérique (NOIRN).
+**Hébergeur du service**, l’entité juridique responsable de l’offre du Service, à savoir la Alliance de recherche numérique du Canada (Alliance).
 
 **Site**, le site Web du Dépôt fédéré de données de recherche (DFDR), accessible à l’adresse [https://www.frdr-dfdr.ca/repo/?locale=fr](https://www.frdr-dfdr.ca/repo/?locale=fr)
 
@@ -140,31 +140,19 @@ Toutes les demandes de retrait temporaire ou permanent de l’accès public ou d
 
 Bien que l’hébergeur du service examine chaque demande de modification, de retrait ou de suppression de contenu du service, celui-ci n’est pas tenu d’approuver ces demandes. Lorsque l’hébergeur du service approuve une telle demande, il en avisera promptement le déposant.
 
-## 7.0 Métadonnées
-
-Le service recueillera des métadonnées accessibles au public qui seront distribuées dans de multiples plateformes et dépôts canadiens.
-
-* Les curateurs veilleront à ce que les métadonnées recueillies soient conformes aux pratiques exemplaires et aux normes reconnues à l’échelle internationale.
-
-* Le Service ne transférera ni n’ingérera de données de recherche dans le cadre de ce processus, à l’exception des fichiers géospatiaux disponibles à partir des jeux de données ouvertes qui sont téléchargés pour fournir un aperçu géospatial du fichier dans le DFDR. Si les données sont librement accessibles, les utilisateurs pourront y accéder à partir du dépôt source.
-
-* Les métadonnées du service peuvent être réutilisées librement dans le cadre de [l'affectation du domaine public Creative Commons (CC0 1.0)](https://creativecommons.org/publicdomain/zero/1.0/).
-
-* Sauf autorisation contraire en vertu des présentes conditions d’utilisation, notamment la section 2.0 ci-dessus, le téléchargement en bloc d’adresses électroniques ou d’autres coordonnées provenant du service n’est pas autorisé. 
-
-## 8.0 Protection de la vie privée
+## 7.0 Protection de la vie privée
 
 L’hébergeur du service respecte la vie privée des utilisateurs et des déposants et ne recueillera, n’utilisera et ne divulguera de renseignements personnels qu’en conformité avec la politique de confidentialité du DFDR, qui fait partie des présentes conditions d’utilisation. L’hébergeur du service incite tous les utilisateurs et les déposants à examiner la politique de confidentialité et à s’en servir pour prendre des décisions éclairées.
 
-## 9.0 Dispositions générales
+## 8.0 Dispositions générales
 
-### 9.1 Suspension et résiliation
+### 8.1 Suspension et résiliation
 
 L’hébergeur du service se réserve le droit de suspendre immédiatement et sans préavis l’accès au site ou au service et l’utilisation de ceux-par toute personne (déposant ou utilisateur) lorsque celle-ci participe ou est soupçonnée de participer à des activités qui contreviennent aux lois applicables ou qui ne sont pas conformes aux présentes conditions d’utilisation.
 
 L’hébergeur du service peut, à sa seule discrétion, accorder un délai de 15 jours pour remédier aux activités qui contreviennent aux présentes conditions d’utilisation ou les faire cesser. Si l’hébergeur du service accorde une période de remédiation et que l’on ne remédie pas aux activités contrevenantes ou qu’on n’y met pas fin au cours de ladite période, ou si l’hébergeur du service détermine que l’on ne peut remédier à la contravention des présentes conditions d’utilisation, votre compte ou votre accès au site et au service sera résilié.
 
-### 9.2 Avis de non-responsabilité
+### 8.2 Avis de non-responsabilité
 
 Le site, le service et le contenu sont mis « TELS QUELS » à la disposition des déposants et des utilisateurs. Vous reconnaissez et convenez que l’utilisation que vous faites du site, du service et du contenu est à vos risques.
 
@@ -178,7 +166,7 @@ L’hébergeur du service ne saurait déclarer ou garantir (ni prendre d’engag
 
 Sauf dans les cas prévus aux présentes et dans la mesure où la loi le permet, l’hébergeur du service se dégage de toute déclaration, garantie ou condition relative au site, au service ou au contenu, qu’elle soit expresse, implicite, légale ou autre ou découle de la poursuite d’activités commerciales, notamment les garanties de titre, d’absence de contrefaçon, de qualité, de rendement, de compatibilité, de qualité marchande ou de réponse à une fin particulière. L’hébergeur du service ne saurait être tenu responsable et n’assume aucune responsabilité en ce qui a trait à tout dommage à votre équipement, à vos données ou à vos autres biens en raison de votre accès au site ou aux services, de votre utilisation de ceux-ci, de votre navigation dans ceux-ci ou de votre téléchargement de tout contenu ou de tout autre matériel, ou de votre incapacité à effectuer l’une ou l’autre des actions ci-dessus. 
 
-### 9.3 Responsabilité et indemnisation
+### 8.3 Responsabilité et indemnisation
 
 Dans la mesure où la loi ne l’interdit pas, l’hébergeur du service ne saurait être responsable de quelque dommage que ce soit, notamment les dommages directs, indirects, accessoires, punitifs, spéciaux ou exemplaires découlant de ce qui suit :
 
@@ -194,28 +182,28 @@ Il s’agit d’une limitation complète de la responsabilité qui s’applique 
 
 Vous êtes tenu(e) d’indemniser et de dégager de toute responsabilité l’hébergeur du service, et de prendre en charge sa défense, en cas de réclamation, de demande, d’action, de perte, de frais, de responsabilité ou de dommages, notamment les frais juridiques raisonnables et les frais en matière d’enquête et de règlement, découlant (i) de l’utilisation ou la mauvaise utilisation du site ou du service; (ii) de votre accès au site, de votre utilisation des services, de l’utilisation du contenu ou d’une contravention aux présentes conditions d’utilisation; (iii) de tout préjudice, du décès ou de dommages matériels occasionnés directement ou indirectement par vous; (iv) de la violation, par vous ou par un tiers utilisant votre compte, de toute propriété intellectuelle ou autre droit d’un tiers de quelque manière que ce soit relativement aux conditions d’utilisation, au site, au service ou au contenu. 
 
-### 9.4 Règlement des différends
+### 8.4 Règlement des différends
 
 Les présentes conditions d’utilisation, votre utilisation du site et du service et tous les différends qui en découlent relativement aux présentes sont exclusivement régis et interprétés conformément aux lois de l’Ontario et aux lois fédérales du Canada applicables en Ontario, sans égard aux conflits de principes de droit. Vous convenez que, même s’il est disponible dans divers territoires de compétence, le site et le service sont réputés être situés uniquement dans la province de l’Ontario, au Canada. En outre, le site et le service sont réputés être de nature passive et ne sauraient favoriser une compétence personnelle sur l’hébergeur du service dans des territoires de compétences autres que la province de l’Ontario. Les parties se soumettent irrévocablement à la compétence exclusive des tribunaux de la province de l’Ontario pour toute action ou procédure découlant de l’application des présentes conditions d’utilisation. Toutefois, vous convenez que rien dans les présentes ne saurait empêcher l’hébergeur du service de demander des recours injonctifs ou d’autres mesures judiciaires urgentes dans quelque territoire de compétence que ce soit.
 
-### 9.5 Intégralité de l’entente et divisibilité
+### 8.5 Intégralité de l’entente et divisibilité
 
 Les présentes conditions d’utilisation, ainsi que la politique de confidentialité et les autres documents incorporés par renvoi dans les présentes, constituent l’intégralité de l’entente conclue entre vous et l’hébergeur du service en ce qui a trait à l’objet des présentes et remplacent toutes les ententes, négociations, communications et propositions (verbales, écrites ou électroniques) antérieures ou existantes entre vous et l’hébergeur du service en ce qui a trait à l’objet des présentes.
 
-### 9.6 Modification des conditions d’utilisation
+### 8.6 Modification des conditions d’utilisation
 
 L’hébergeur du service se réserve le droit, à sa seule discrétion, de modifier ou de remplacer les présentes conditions d’utilisation à tout moment, auquel cas les conditions d’utilisation modifiées ou mises à jour remplaceront les versions précédentes. Si l’hébergeur du service apporte des modifications aux présentes, les conditions d’utilisation mises à jour seront affichées sur le site.
 
 Il vous incombe de vérifier périodiquement les conditions d’utilisation au cas où des modifications y auraient été apportées. Votre utilisation continue du site ou du service à la suite de l’affichage de modifications aux conditions d’utilisation constitue une acceptation de ces modifications.
 
-### 9.7 Pour nous joindre
+### 8.7 Pour nous joindre
 
 Si vous avez des questions ou des commentaires au sujet du site ou du service, si vous n’êtes pas certain(e) que votre utilisation prévue est conforme aux présentes conditions d’utilisation ou si vous demandez l’autorisation pour une utilisation qui sort du cadre des présentes conditions d’utilisation, veuillez communiquer avec nous au [support@frdr-dfdr.ca](mailto:support@frdr-dfdr.ca).
 
 Si vous avez des questions ou des préoccupations au sujet de la collecte, de l’utilisation ou de la divulgation de renseignements personnels concernant le DFDR, veuillez consulter la politique sur la protection de la vie privée ou communiquer avec nous au [privacy@frdr-dfdr.ca](mailto:privacy@frdr-dfdr.ca).
 
-### 9.8 Droits patrimoniaux
+### 8.8 Droits patrimoniaux
 
 Vous reconnaissez et acceptez que tous les droits, titres et intérêts relatifs aux sites, au service, à toutes les données supplémentaires ajoutées par l’hébergeur du service au contenu et à tous marque de commerce, logiciel de recherche, guide d’utilisateur, documentation et autres droits de propriété intellectuelle créés par ou pour le compte de l’hébergeur du service concernant le site ou le service, notamment la soumission du contenu, demeurent la propriété exclusive de l’hébergeur du service et de ses titulaires de licence.
 
-Derrière révision: 2021-11-23
+Derrière révision: 2023-06-14

--- a/docs/fr/confidentialité.md
+++ b/docs/fr/confidentialité.md
@@ -1,4 +1,4 @@
-La Politique de confidentialité suivante s’applique au site Web du Dépôt fédéré de données de recherche (DFDR) (le site), <a href="https://www.frdr-dfdr.ca/repo/?locale=fr">https://www.frdr-dfdr.ca/repo/?locale=fr</a>, et aux services offerts dans le site. Le service est offert par la Nouvelle organisation d’infrastructure de recherche numérique (NOIRN) (ci-après l’hébergeur du service).
+La Politique de confidentialité suivante s’applique au site Web du Dépôt fédéré de données de recherche (DFDR) (le site), <a href="https://www.frdr-dfdr.ca/repo/?locale=fr">https://www.frdr-dfdr.ca/repo/?locale=fr</a>, et aux services offerts dans le site. Le service est offert par la Alliance de recherche numérique du Canada (Alliance) (ci-après l’hébergeur du service).
 
 ## Énoncé de confidentialité
 
@@ -26,7 +26,7 @@ On entend par :
 
 **Service**, les services disponibles dans le site proposés par l’hébergeur du service.
 
-**Hébergeur du service**, l’entité juridique chargée d’offrir le service, soit la Nouvelle organisation d’infrastructure de recherche numérique (NOIRN).
+**Hébergeur du service**, l’entité juridique responsable de l’offre du Service, à savoir la Alliance de recherche numérique du Canada (Alliance).
 
 **Site**, le site Web du Dépôt fédéré de données de recherche (DFDR), accessible à l’adresse <a href="https://www.frdr-dfdr.ca/repo/?locale=fr">https://www.frdr-dfdr.ca/repo/?locale=fr</a>
 
@@ -166,4 +166,4 @@ Si vous avez des questions ou des préoccupations au sujet de la collecte, de l�
 
 L’hébergeur du service se réserve le droit de suspendre l’utilisation par toute partie (déposant ou utilisateur) du site ou du service si celle-ci se livre ou est soupçonnée de se livrer à des activités qui violent les lois applicables en matière d’accès à l’information et de protection de la vie privée.
 
-Dernière mise à jour : 2021-04-26
+Dernière mise à jour : 2023-06-14

--- a/docs/fr/glossaire.md
+++ b/docs/fr/glossaire.md
@@ -10,7 +10,7 @@
 
 **Service** : Les services mis à la disposition sur le site offert par l’hébergeur du service.
 
-**Hôte du service** : L’entité juridique responsable de l’offre du Service, à savoir la Nouvelle organisation d’infrastructure de recherche numérique (NOIRN).
+**Hôte du service** : L’entité juridique responsable de l’offre du Service, à savoir la Alliance de recherche numérique du Canada (Alliance).
 
 **Site** : Site web du Dépôt fédéré de données de recherche (DFDR) — https://www.frdr-dfdr.ca/
 
@@ -18,4 +18,4 @@
 
 **Utilisateur** : Une personne qui utilise le service en naviguant sur le site ou en téléchargeant du contenu.
 
-*Dernière révision : 2021-05-18*
+*Dernière révision : 2023-06-12*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,6 @@ nav:
         - "Collections Development Policy": en/collections_development.md
         - "Data Retention and Deaccession Policy": en/data_retention.md
         - "Data Submission Policy": en/data_submission.md
-        - "Metadata Harvesting Policy": en/metadata_harvesting.md
         - "Preservation Policy": en/preservation.md
         - "Glossary of Terms": en/glossary.md
     - French:
@@ -22,7 +21,6 @@ nav:
         - "Politique en matière de création de collections": fr/création_collections.md
         - "Politique en matière de rétention et de suppression des données": fr/rétention_des_données.md
         - "Politique en matière de soumission de données": fr/soumission_données.md
-        - "Politique en matière de moissonnage de métadonnées": fr/moissonnage_métadonnées.md
         - "Politique de préservation": fr/préservation.md
         - "Glossaire terminologique": fr/glossaire.md
 
@@ -42,7 +40,6 @@ extra:
             "Collections Development Policy": fr/création_collections/
             "Data Retention and Deaccession Policy": fr/rétention_des_données/
             "Data Submission Policy": fr/soumission_données/
-            "Metadata Harvesting Policy": fr/moissonnage_métadonnées/
             "Preservation Policy": fr/préservation/
             "Glossary of Terms": fr/glossaire/
         fr:
@@ -52,6 +49,5 @@ extra:
             "Politique en matière de création de collections": en/collections_development/
             "Politique en matière de rétention et de suppression des données": en/data_retention/
             "Politique en matière de soumission de données": en/data_submission/
-            "Politique en matière de moissonnage de métadonnées": en/metadata_harvesting/
             "Politique de préservation": en/preservation/
             "Glossaire terminologique": en/glossary/


### PR DESCRIPTION
1. Remove Metadata harvesting policy (EN and FR)
2. From Access and Reuse policy, remove following text from first para. Same change required for FR-policy, too
 "See the Metadata Harvesting Policy for complete information about the Service’s metadata harvesting protocols and activities associated with the search and discovery of third-party data repositories."
3. From Terms of Use policy, please remove entire 7.0 Metadata section and update consequent numbering. Change required in both languages.
4. In Glossary and FRDR policies, update definition for service host to the following:
"Service Host: The legal entity responsible for offering the Service, being the Digital Research Alliance of Canada (Alliance)."
"L’entité juridique responsable de l’offre du Service, à savoir la Alliance de recherche numérique du Canada (Alliance)."